### PR TITLE
Added endpoint for direct communication with the eIDAS connector.

### DIFF
--- a/src/main/java/se/swedenconnect/eid/sp/controller/SamlController.java
+++ b/src/main/java/se/swedenconnect/eid/sp/controller/SamlController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Sweden Connect
+ * Copyright 2018-2019 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,25 +94,31 @@ public class SamlController extends BaseController {
    *          the HTTP request
    * @param response
    *          the HTTP response
+   * @param selectedIdp
+   *          the selected IdP
+   * @param country
+   *          optional parameter for direct requests to an eIDAS country
    * @param debug
    *          the debug flag
    * @return a model and view object
    * @throws ApplicationException
    *           for errors
    */
-  @PostMapping("/request")
+  @RequestMapping("/request")
   public ModelAndView sendRequest(HttpServletRequest request, HttpServletResponse response,
       @RequestParam("selectedIdp") String selectedIdp,
+      @RequestParam(value = "country", required = false) String country,
       @RequestParam(value = "debug", required = false, defaultValue = "false") Boolean debug) throws ApplicationException {
 
-    log.debug("Request for generating an AuthnRequest to '{}' [client-ip-address='{}', debug='{}']", selectedIdp, request.getRemoteAddr(),
-      debug);
+    log.debug("Request for generating an AuthnRequest to '{}' [client-ip-address='{}', debug='{}', country='{}']", selectedIdp, request.getRemoteAddr(),
+      debug, country);
 
     try {
       HttpSession session = request.getSession();
 
       AuthnRequestGeneratorInput input = new AuthnRequestGeneratorInput(selectedIdp);
       input.setDebug(debug);
+      input.setCountry(country);
 
       RequestHttpObject<AuthnRequest> authnRequest = this.authnRequestGenerator.generateRequest(input);
 
@@ -266,7 +272,7 @@ public class SamlController extends BaseController {
     else {
       log.error("Uknown LoA: {}", loa);
     }
-    
+
     final boolean isEidas = loaEnum.isEidasUri();
 
     List<Attribute> unknownAttributes = new ArrayList<>();

--- a/src/main/java/se/swedenconnect/eid/sp/controller/SpController.java
+++ b/src/main/java/se/swedenconnect/eid/sp/controller/SpController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Sweden Connect
+ * Copyright 2018-2019 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,12 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.mobile.device.Device;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
@@ -47,6 +49,10 @@ public class SpController extends BaseController {
   @Autowired
   private IdpListConfiguration idpListConfiguration;
 
+  /** The entityID for the eIDAS connector. */
+  @Value("${sp.eidas-connector.entity-id}")
+  private String eidasConnectorEntityId;
+
   /**
    * Controller method for the home endpoint.
    * 
@@ -63,12 +69,44 @@ public class SpController extends BaseController {
     mav.addObject("debug", debug);
     mav.addObject("idpList", this.idpListConfiguration.getIdps()
       .stream()
-      .filter(idp -> device.isNormal() || idp.isMobileUse()) 
+      .filter(idp -> device.isNormal() || idp.isMobileUse())
       .map(i -> i.getIdpModel(LocaleContextHolder.getLocale()))
       .collect(Collectors.toList()));
 
     log.trace("Adding IdPs {}", this.idpListConfiguration.getIdps());
     return mav;
+  }
+
+  /**
+   * Controller that by-passes the discovery page and goes directly to the eIDAS connector.
+   * 
+   * @param debug
+   *          debug flag
+   * @return a redirect string to the SAML request endpoint
+   */
+  @GetMapping("/eidas")
+  public ModelAndView eidas(
+      @RequestParam(value = "debug", required = false, defaultValue = "false") Boolean debug) {
+
+    return new ModelAndView(String.format("redirect:/saml2/request?selectedIdp=%s&debug=%s", this.eidasConnectorEntityId, debug));
+  }
+
+  /**
+   * Controller that by-passed the discovery page and goes directly to the eIDAS connector with a pre-selected country.
+   * 
+   * @param country
+   *          the two-letter country code for the country to send the request from the connector to
+   * @param debug
+   *          debug flag
+   * @return a redirect string to the SAML request endpoint
+   */
+  @GetMapping("/eidas/{country}")
+  public ModelAndView eidasCountry(
+      @PathVariable(value = "country", required = true) String country,
+      @RequestParam(value = "debug", required = false, defaultValue = "false") Boolean debug) {
+
+    return new ModelAndView(String.format("redirect:/saml2/request?selectedIdp=%s&country=%s&debug=%s", 
+      this.eidasConnectorEntityId, country, debug));
   }
 
   /**

--- a/src/main/java/se/swedenconnect/eid/sp/saml/AuthnRequestGeneratorInput.java
+++ b/src/main/java/se/swedenconnect/eid/sp/saml/AuthnRequestGeneratorInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Sweden Connect
+ * Copyright 2018-2019 Sweden Connect
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,10 @@ public class AuthnRequestGeneratorInput extends AbstractRequestGeneratorInput {
   @Getter
   @Setter
   private boolean debug;
+  
+  @Getter
+  @Setter
+  private String country;
 
   /** The IdP entity ID. */
   private String idpEntityID;

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -21,6 +21,11 @@ sp.federation.metadata.url=classpath:local/local-metadata.xml
 sp.discovery.static-idp-configuration=classpath:local/idp-disco-local.properties
 
 #
+# eIDAS
+#
+sp.eidas-connector.entity-id=https://eunode.eidastest.se/idp2
+
+#
 # Log levels
 #
 logging.level.root=INFO

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -17,6 +17,11 @@ sp.discovery.ignore-contracts=false
 sp.discovery.static-idp-configuration=classpath:prod/idp-disco-prod.properties
 
 #
+# eIDAS
+#
+sp.eidas-connector.entity-id=https://connector.eidas.swedenconnect.se/eidas
+
+#
 # Log levels
 #
 logging.level.testmyeid=INFO

--- a/src/main/resources/application-qa.properties
+++ b/src/main/resources/application-qa.properties
@@ -17,6 +17,11 @@ sp.discovery.ignore-contracts=true
 sp.discovery.static-idp-configuration=classpath:qa/idp-disco-qa.properties
 
 #
+# eIDAS
+#
+sp.eidas-connector.entity-id=https://qa.connector.eidas.swedenconnect.se/eidas
+
+#
 # Log levels
 #
 logging.level.root=WARN

--- a/src/main/resources/application-sandbox.properties
+++ b/src/main/resources/application-sandbox.properties
@@ -14,6 +14,11 @@ sp.federation.metadata.validation-certificate=classpath:sandbox/sandbox-metadata
 sp.discovery.static-idp-configuration=classpath:sandbox/idp-disco-sandbox.properties
 
 #
+# eIDAS
+#
+sp.eidas-connector.entity-id=https://dev.connector.swedenconnect.se/eidas
+
+#
 # For debugging
 #
 sp.debug-base-uri=https://localhost:9445


### PR DESCRIPTION
The endpoint /eidas directs the user directly to the eIDAS connector
and the endpoint /eidas/XX directs the user to the eIDAS connector with
information about the desired country (thus by-passing the connector
discovery page).